### PR TITLE
Update Scatter Plots

### DIFF
--- a/src/app/(pages)/dashboard/page.tsx
+++ b/src/app/(pages)/dashboard/page.tsx
@@ -20,7 +20,7 @@ function Dashboard({ }) {
   const combineYearsDashboard = useDataStore((state) => state.combineYearsDashboard);
   const toggleCombineYears = useDataStore((state) => state.toggleCombineYears);
 
-  const yearsList: string[] = ['2024', '2023', '2022', '2021', '2020'];
+  const yearsList: string[] = ['2025', '2024', '2023', '2022', '2021', '2020'];
 
   const [yearClickState, setYearClickState] = useState<boolean[]>(yearsList.map((year: string) => selectedYears.includes(parseInt(year))));
 

--- a/src/app/api/rankings/route.ts
+++ b/src/app/api/rankings/route.ts
@@ -1,5 +1,5 @@
 import { fetchRankings } from '@/app/lib/data'; // Adjust path
-
+import { FetchRankingsResult } from '@/app/lib/definitions';
 
 export async function GET(request: Request) {
     const { searchParams } = new URL(request.url);
@@ -16,10 +16,10 @@ export async function GET(request: Request) {
             console.log(hidden)
             console.log(hidden)
             if (!(hidden?.toLowerCase() === 'true')) {
-                const tempData = newRankings.map((entry: any) => { return entry.score === null ? { ...entry, score: "-10" } : entry })
+                const tempData = newRankings.map((entry: FetchRankingsResult) => { return entry.score === null ? { ...entry, score: "-10" } : entry })
                 return Response.json({ newRankings: tempData, origRankings: newRankings })
             }
-            const tempData = newRankings.filter((entry: any) => entry.score)
+            const tempData = newRankings.filter((entry: FetchRankingsResult) => entry.score)
             return Response.json({ newRankings: tempData, origRankings: newRankings })
 
 

--- a/src/app/api/rankings/route.ts
+++ b/src/app/api/rankings/route.ts
@@ -13,8 +13,6 @@ export async function GET(request: Request) {
     if (publication_ids_list && years_list) {
         const newRankings = await fetchRankings(publication_ids_list, years_list);
         if (newRankings) {
-            console.log(hidden)
-            console.log(hidden)
             if (!(hidden?.toLowerCase() === 'true')) {
                 const tempData = newRankings.map((entry: FetchRankingsResult) => { return entry.score === null ? { ...entry, score: "-10" } : entry })
                 return Response.json({ newRankings: tempData, origRankings: newRankings })

--- a/src/app/api/rankings/route.ts
+++ b/src/app/api/rankings/route.ts
@@ -6,13 +6,23 @@ export async function GET(request: Request) {
 
     const publication_ids = searchParams.get('publication_ids');
     const years = searchParams.get('years')
+    const hidden = searchParams.get('hidden');
 
     const publication_ids_list = publication_ids?.split(',').map(Number);
     const years_list = years?.split(',').map(Number);
     if (publication_ids_list && years_list) {
         const newRankings = await fetchRankings(publication_ids_list, years_list);
         if (newRankings) {
-            return Response.json({ newRankings })
+            console.log(hidden)
+            console.log(hidden)
+            if (!(hidden?.toLowerCase() === 'true')) {
+                const tempData = newRankings.map((entry: any) => { return entry.score === null ? { ...entry, score: "-10" } : entry })
+                return Response.json({ newRankings: tempData, origRankings: newRankings })
+            }
+            const tempData = newRankings.filter((entry: any) => entry.score)
+            return Response.json({ newRankings: tempData, origRankings: newRankings })
+
+
         }
     } else {
         return Response.json({ newRankings: [] })

--- a/src/app/lib/data.ts
+++ b/src/app/lib/data.ts
@@ -1,5 +1,5 @@
 import { sql, createClient } from '@vercel/postgres';
-import type { Publication, User, Album, Review } from './definitions';
+import type { Publication, User, Album, Review, FetchRankingsResult } from './definitions';
 
 export async function fetchPublications() {
     try {
@@ -52,7 +52,7 @@ export async function fetchRankings(publication_ids: number[], years_list: numbe
         LEFT JOIN reviews as t2
         ON t1.album_id = t2.album_id AND t1.publication_id = t2.publication_id
         WHERE t1.publication_id IN (${publication_ids_string}) AND t1.year IN (${years_string})`);
-        const rankings = data.rows;
+        const rankings: FetchRankingsResult[] = data.rows;
         return rankings;
     } catch (error) {
         console.error('Database Error:', error)

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -8,6 +8,15 @@ export interface Publication {
 }
 
 
+export interface FetchRankingsResult {
+    id: number;
+    publication_id: number;
+    album_id: number;
+    rank: number;
+    year: number;
+    score: number | null;
+}
+
 export interface BinnedAlbums {
     [key: string]: Album[]
 }

--- a/src/app/lib/definitions.ts
+++ b/src/app/lib/definitions.ts
@@ -74,7 +74,7 @@ export interface Album {
 }
 
 export interface AlbumWithScore extends Album {
-    avg_score: number;
+    avg_score: number | null;
     reviews: Review[];
 }
 

--- a/src/app/ui/AlbumList/Album/component.tsx
+++ b/src/app/ui/AlbumList/Album/component.tsx
@@ -39,10 +39,10 @@ const AlbumComponent = ({ onClick, avgScore, album, reviews, rankings }: AlbumCo
 
         const val = ((reviews.length * 44) - 52) / 2
         const positionLeft = targetRect.width + 40;
-        let positionTop = targetRect.top - val;
+        let positionTop = targetRect.top - val - 20;
         // let positionTop = targetRect.top
         if (positionTop + (reviews.length * 44) > viewportHeight) {
-            positionTop = targetRect.top - 2 * val - 5; //5 for adding some 'padding'
+            positionTop = targetRect.top - 2 * val - 30; //5 for adding some 'padding'
         }
 
         setPosition({
@@ -65,25 +65,29 @@ const AlbumComponent = ({ onClick, avgScore, album, reviews, rankings }: AlbumCo
                 }}
                 className={clsx(styles.albumToolTipSmall, visible ? styles.visible : null)}
             >
-
-                {reviews.map((review: Review) => {
-                    const currPublication = publicationsSelected.find((publication: Publication) => review.publication_id === publication.id);
-                    const pubIndex = publicationsSelected.findIndex(item => item.id === currPublication?.id);
+                {publicationsSelected.map((publication: Publication, idx: number) => {
+                    const rank = rankings.find((entry: Ranking) => entry.publication_id == publication.id) ?
+                        <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[publication.id % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
+                            #{rankings.find((entry: Ranking) => entry.publication_id == publication.id)?.rank}
+                        </div> : null
+                    const review = reviews.find((entry: Review) => entry.publication_id == publication.id) ?
+                        <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[publication.id % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
+                            {reviews.find((entry: Review) => entry.publication_id == publication.id)?.score}
+                        </div> : rank ? <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[publication.id % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
+                            N/A
+                        </div> : null
                     return (
-                        <div key={`tooltip-${review.id}`} style={{ display: 'flex', flexDirection: 'row', gap: '10px', alignItems: 'center', justifyContent: 'flex-start', margin: '5px 0px' }}>
-                            <img
-                                className='pub-icon'
-                                src={`/images/publications/${currPublication?.unique_name}.webp`}
-                                width="30px"
-                                height="30px"
-                            />
-                            <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[pubIndex], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
-                                {review.score}
+                        !review && !rank ? null :
+                            <div key={`tooltip-${publication.id}`} style={{ display: 'flex', flexDirection: 'row', gap: '10px', alignItems: 'center', justifyContent: 'flex-start', margin: '5px 0px' }}>
+                                <img
+                                    className='pub-icon'
+                                    src={`/images/publications/${publication.unique_name}.webp`}
+                                    width="30px"
+                                    height="30px"
+                                />
+                                {review}
+                                {rank}
                             </div>
-                            {rankings.find((entry: Ranking) => entry.publication_id == review.publication_id) ? <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[pubIndex], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
-                                #{rankings.find((entry: Ranking) => entry.publication_id == review.publication_id)?.rank}
-                            </div> : null}
-                        </div>
                     )
                 })}
             </div>

--- a/src/app/ui/AlbumList/Album/component.tsx
+++ b/src/app/ui/AlbumList/Album/component.tsx
@@ -67,13 +67,13 @@ const AlbumComponent = ({ onClick, avgScore, album, reviews, rankings }: AlbumCo
             >
                 {publicationsSelected.map((publication: Publication, idx: number) => {
                     const rank = rankings.find((entry: Ranking) => entry.publication_id == publication.id) ?
-                        <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[publication.id % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
+                        <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[idx % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
                             #{rankings.find((entry: Ranking) => entry.publication_id == publication.id)?.rank}
                         </div> : null
                     const review = reviews.find((entry: Review) => entry.publication_id == publication.id) ?
-                        <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[publication.id % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
+                        <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[idx % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
                             {reviews.find((entry: Review) => entry.publication_id == publication.id)?.score}
-                        </div> : rank ? <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[publication.id % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
+                        </div> : rank ? <div className={styles.score} style={{ color: 'hsl(var(--gray-100))', backgroundColor: chartColorScheme[idx % 6], width: '30px', height: '30px', marginTop: 0, border: '2px solid black' }}>
                             N/A
                         </div> : null
                     return (

--- a/src/app/ui/AlbumList/Album/component.tsx
+++ b/src/app/ui/AlbumList/Album/component.tsx
@@ -15,7 +15,7 @@ interface AlbumComponentProps {
     album: Album,
     reviews: Review[],
     rankings: Ranking[],
-    avgScore: number,
+    avgScore: number | null,
     onClick?: () => void;
 }
 
@@ -118,7 +118,7 @@ const AlbumComponent = ({ onClick, avgScore, album, reviews, rankings }: AlbumCo
                 </div>
                 <div className={styles.right}>
                     <div className={styles.review}>
-                        <div style={{ marginTop: 0, fontSize: '0.9rem', marginRight: '5px' }} className={styles.score}>{avgScore}</div>
+                        <div style={{ marginTop: 0, fontSize: '0.9rem', marginRight: '5px' }} className={styles.score}>{avgScore ?? 'N/A'}</div>
                     </div>
                 </div>
             </div>

--- a/src/app/ui/AlbumList/AlbumDetailModal/AlbumReviewsChart/component.tsx
+++ b/src/app/ui/AlbumList/AlbumDetailModal/AlbumReviewsChart/component.tsx
@@ -46,7 +46,7 @@ const AlbumReviewsChart = ({ reviews, publicationsSelected, chartColorScheme }: 
                 return {
                     label: review.name,
                     score: review.score,
-                    color: pub_index === -1 ? 'steelblue' : chartColorScheme[pub_index],
+                    color: pub_index === -1 ? 'steelblue' : chartColorScheme[pub_index % 6],
                     opacity: pub_index === -1 ? 0.6 : 1
                 }
             })

--- a/src/app/ui/AlbumList/AlbumDetailModal/AlbumReviewsChart/component.tsx
+++ b/src/app/ui/AlbumList/AlbumDetailModal/AlbumReviewsChart/component.tsx
@@ -59,8 +59,6 @@ const AlbumReviewsChart = ({ reviews, publicationsSelected, chartColorScheme }: 
             const variance = reviewsData.reduce((sum, item) => sum + Math.pow(parseInt(item.score.toString()) - mean, 2), 0) / reviewsData.length;
             const stdDev = Math.sqrt(variance);
 
-            console.log(mean, stdDev)
-
             setMeanData([
                 {
                     label: 'Average Score',

--- a/src/app/ui/AlbumList/AlbumDetailModal/component.tsx
+++ b/src/app/ui/AlbumList/AlbumDetailModal/component.tsx
@@ -40,7 +40,6 @@ interface AlbumReviewChartWrapperProps {
 
 
 const AlbumReviewChartWrapper = ({ loading, chartColorScheme, publications, data }: AlbumReviewChartWrapperProps) => {
-    console.log(loading)
     if (loading) return (
         <div style={{ width: '625px', height: '250px', display: 'flex', flexDirection: 'row', alignItems: 'center', justifyContent: 'center' }}>
             <div style={{ fontSize: '1.0rem' }}>Loading Reviews</div><LoadingIcon visible={true} />

--- a/src/app/ui/AlbumList/component.tsx
+++ b/src/app/ui/AlbumList/component.tsx
@@ -52,7 +52,7 @@ export interface SelectedAlbumInfo {
     album: AlbumWithScore,
     reviews: Review[],
     rankings: Ranking[],
-    avgScore: number,
+    avgScore: number | null,
 }
 
 const AlbumList = () => {
@@ -158,13 +158,15 @@ const AlbumList = () => {
 
             const albumWithScore = {
                 ...album,
-                avgScore: 0,
+                avgScore: null,
                 reviews
             }
-            let avgScore = 0;
+            let avgScore: number | null = 0;
             if (albumWithScore.reviews && albumWithScore.reviews.length > 0) {
                 const totalScore = albumWithScore.reviews.reduce((sum, review) => sum + parseFloat(review.score.toString()), 0);
                 avgScore = Math.round((totalScore / albumWithScore.reviews.length)) / 10; // Set average score
+            } else {
+                avgScore = null
             }
             return {
                 ...albumWithScore,
@@ -239,7 +241,7 @@ const AlbumList = () => {
         setModalOpened((prev) => !prev);
     }
 
-    const handleAlbumClick = (album: AlbumWithScore, reviews: Review[], rankings: Ranking[], avgScore: number) => {
+    const handleAlbumClick = (album: AlbumWithScore, reviews: Review[], rankings: Ranking[], avgScore: number | null) => {
         setSelectedAlbumInfo({
             album,
             reviews,

--- a/src/app/ui/DashboardComponent/ChartComponent/BarChart/component.tsx
+++ b/src/app/ui/DashboardComponent/ChartComponent/BarChart/component.tsx
@@ -60,7 +60,7 @@ const BarChart = ({ publication_id, years }: BarChartProps): JSX.Element => {
     const initializeBarChart = useDataStore((state) => state.initializeBarChart);
 
 
-    const color = chartColorScheme[publicationsSelected.findIndex(item => item.id === publication_id)]
+    const color = chartColorScheme[publicationsSelected.findIndex(item => item.id === publication_id) % 6]
 
     // Generate state for tracking marks for clicked bars
     const [clickedData, setClickedData] = useState<BarData[]>([]);

--- a/src/app/ui/DashboardComponent/ChartComponent/ScatterPlot/component.tsx
+++ b/src/app/ui/DashboardComponent/ChartComponent/ScatterPlot/component.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react'
 import { Vega } from "react-vega";
 import { getCSSVariableValue } from '@/app/lib/getCSSVariableValue';
 import { useTheme } from '@/providers/theme-provider';
-import type { Publication } from '@/app/lib/definitions';
+import type { FetchRankingsResult, Publication } from '@/app/lib/definitions';
 import { useDataStore } from "@/providers/data-store-provider";
 import useSWR from 'swr';
 import { LoadingIcon } from '@bbollen23/brutal-paper';
@@ -56,7 +56,7 @@ const ScatterPlot = ({ publication_id, years, setErrorNumber, hidden }: ScatterP
     useEffect(() => {
         if (data) {
             addRankings(data.newRankings, years);
-            setErrorNumber(data.origRankings.filter((entry: any) => entry.score === null).length)
+            setErrorNumber(data.origRankings.filter((entry: FetchRankingsResult) => entry.score === null).length)
         }
     }, [data])
 

--- a/src/app/ui/DashboardComponent/ChartComponent/ScatterPlot/component.tsx
+++ b/src/app/ui/DashboardComponent/ChartComponent/ScatterPlot/component.tsx
@@ -37,6 +37,8 @@ const ScatterPlot = ({ publication_id, years, setErrorNumber, hidden }: ScatterP
     const addRankings = useDataStore((state) => state.addRankings);
     const brushState = useDataStore((state) => state.brushState);
 
+    const [hasMounted, setHasMounted] = useState(false);
+
     // Used only to render initial state when re-mounting
     const [currBrushState, setBrushState] = useState({
         x: 0,
@@ -61,13 +63,16 @@ const ScatterPlot = ({ publication_id, years, setErrorNumber, hidden }: ScatterP
     }, [data])
 
     useEffect(() => {
-        setBrushState({
-            x: 0,
-            y: 0,
-            width: 0,
-            height: 0
-        });
-        brushSelection(0, 0, 0, 0, 0, 0, 0, 0, years, publication_id)
+        // Should not run when mounted.
+        if (hasMounted) {
+            setBrushState({
+                x: 0,
+                y: 0,
+                width: 0,
+                height: 0
+            });
+            brushSelection(0, 0, 0, 0, 0, 0, 0, 0, years, publication_id)
+        }
     }, [hidden])
 
     useEffect(() => {
@@ -77,6 +82,7 @@ const ScatterPlot = ({ publication_id, years, setErrorNumber, hidden }: ScatterP
         if (brushState[years[0]] && brushState[years[0]][publication_id]) {
             setBrushState(brushState[years[0]][publication_id])
         }
+        setHasMounted(true)
     }, [])
 
 

--- a/src/app/ui/DashboardComponent/ChartComponent/component.module.scss
+++ b/src/app/ui/DashboardComponent/ChartComponent/component.module.scss
@@ -59,3 +59,18 @@
     align-items: center;
     gap: 40px;
 }
+
+.error {
+    cursor: pointer;
+    display: flex;
+    flex-direction: row;
+    gap: 5px;
+    padding: 5px;
+    border-radius: 4px;
+    margin-right: 10px;
+
+}
+
+.error:hover {
+    background-color: var(--bp-theme-item-hover-color-dark);
+}

--- a/src/app/ui/DashboardComponent/ChartComponent/component.tsx
+++ b/src/app/ui/DashboardComponent/ChartComponent/component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import type { Publication } from "@/app/lib/definitions";
 import styles from "./component.module.scss";

--- a/src/stores/data-store.ts
+++ b/src/stores/data-store.ts
@@ -2,7 +2,12 @@ import { createStore } from 'zustand/vanilla'
 import type { Filter, Publication, Review, Ranking, CurrentReviews, CurrentRankings, AlbumIdsSelected, AlbumIdsSelectedRanking, CurrentBarChartMetadata } from '@/app/lib/definitions';
 
 
-
+export interface BrushState {
+    x: number,
+    y: number,
+    width: number,
+    height: number
+}
 
 export type DataStoreState = {
     // Used
@@ -17,6 +22,8 @@ export type DataStoreState = {
     upsetConsolidate: boolean;
     upsetInclusive: boolean;
     barChartMetadata: CurrentBarChartMetadata;
+    brushState: Record<string, Record<string, BrushState>>;
+    noScoreRankHiddenState: Record<string, Record<string, boolean>>;
 
     // Coloring
     chartColorScheme: string[];
@@ -38,7 +45,7 @@ export type DataStoreActions = {
     clickBarSelection: (bin0: number, bin1: number, publication_id: number, years: number[]) => void;
     clearBarSelection: (publication_id: number, years: number[]) => void;
     selectAllBarSelection: (publication_id: number, years: number[]) => void;
-    brushSelection: (x1: number, x2: number, y1: number, y2: number, years: number[], publication_id: number) => void;
+    brushSelection: (x1: number, x2: number, y1: number, y2: number, x: number, y: number, width: number, height: number, years: number[], publication_id: number) => void;
     addReviews: (reviews: Review[], years: number[]) => void;
     addRankings: (rankings: Ranking[], years: number[]) => void;
     setSelectedYears: (year: string[]) => void;
@@ -47,6 +54,7 @@ export type DataStoreActions = {
     removeFilter: (filter: Filter) => void;
     toggleConsolidate: () => void;
     toggleInclusive: () => void;
+    toggleNoScoreRankHiddenState: (years: number[], publication_id: number) => void;
 
 
     // Currently Unused
@@ -78,7 +86,9 @@ export const defaultInitialState: DataStoreState = {
     filterPlotBarColors: {},
     upsetConsolidate: false,
     upsetInclusive: false,
-    barChartMetadata: {}
+    barChartMetadata: {},
+    brushState: {},
+    noScoreRankHiddenState: {}
 }
 
 export const initDataStore = (): DataStoreState => {
@@ -111,7 +121,9 @@ export const initDataStore = (): DataStoreState => {
         },
         upsetConsolidate: false,
         upsetInclusive: false,
-        barChartMetadata: {}
+        barChartMetadata: {},
+        brushState: {},
+        noScoreRankHiddenState: {}
 
     }
 }
@@ -370,22 +382,46 @@ export const createDataStore = (
                 }
             })
         },
-        brushSelection: (x1: number, x2: number, y1: number, y2: number, years: number[], publication_id: number) => {
+        brushSelection: (x1: number, x2: number, y1: number, y2: number, x: number, y: number, width: number, height: number, years: number[], publication_id: number) => {
             set((state) => {
+                console.log(x1, x2, y1, y2, x, y, width, height);
                 const updatedAlbumIds: AlbumIdsSelectedRanking = { ...state.selectedAlbumIdsRankings }
-
+                const updatedBrushState = { ...state.brushState }
                 years.forEach((year) => {
-                    const tempAlbumIds = [...state.rankings[year][publication_id]].filter((ranking: Ranking) => ranking.rank >= Math.min(x1, x2) && ranking.rank <= Math.max(x1, x2) && ranking.score >= Math.min(y1, y2) && ranking.score <= Math.max(y1, y2)).map((entry: Ranking) => entry.album_id);
+                    if (state.rankings[year] && state.rankings[year][publication_id]) {
+                        const tempAlbumIds = [...state.rankings[year][publication_id]].filter((ranking: Ranking) => ranking.rank >= Math.min(x1, x2) && ranking.rank <= Math.max(x1, x2) && ranking.score >= Math.min(y1, y2) && ranking.score <= Math.max(y1, y2)).map((entry: Ranking) => entry.album_id);
 
-                    if (!updatedAlbumIds[year]) {
-                        updatedAlbumIds[year] = {};
+                        if (!updatedAlbumIds[year]) {
+                            updatedAlbumIds[year] = {};
+                        }
+
+                        if (!updatedBrushState[year]) {
+                            updatedBrushState[year] = {}
+                        }
+
+                        updatedAlbumIds[year][publication_id] = tempAlbumIds;
+                        updatedBrushState[year][publication_id] = { x, y, width, height };
                     }
 
-                    updatedAlbumIds[year][publication_id] = tempAlbumIds;
                 })
 
                 return {
-                    selectedAlbumIdsRankings: updatedAlbumIds
+                    selectedAlbumIdsRankings: updatedAlbumIds,
+                    brushState: updatedBrushState
+                }
+            })
+        },
+        toggleNoScoreRankHiddenState: (years: number[], publication_id: number) => {
+            set((state) => {
+                const updatedHiddenState = { ...state.noScoreRankHiddenState }
+                years.forEach((year) => {
+                    if (!updatedHiddenState[year]) {
+                        updatedHiddenState[year] = {}
+                    }
+                    updatedHiddenState[year][publication_id] = updatedHiddenState[year][publication_id] === undefined ? false : !updatedHiddenState[year][publication_id]
+                })
+                return {
+                    noScoreRankHiddenState: updatedHiddenState
                 }
             })
         }

--- a/src/stores/data-store.ts
+++ b/src/stores/data-store.ts
@@ -384,7 +384,6 @@ export const createDataStore = (
         },
         brushSelection: (x1: number, x2: number, y1: number, y2: number, x: number, y: number, width: number, height: number, years: number[], publication_id: number) => {
             set((state) => {
-                console.log(x1, x2, y1, y2, x, y, width, height);
                 const updatedAlbumIds: AlbumIdsSelectedRanking = { ...state.selectedAlbumIdsRankings }
                 const updatedBrushState = { ...state.brushState }
                 years.forEach((year) => {


### PR DESCRIPTION
# Closes
#3 #4 #5 

# Description

1.) Ensures brush retains on re-mount
2.) Added a "show/hide albums without original scores". Some albums were listed in rankings without original scores from that publication. When displayed, they are shown at the -10 value mark with a label "No Score" in white.
3.) Fixed too many publications running over the chart colors.
4.) Allowed tooltips to show just rank if there is no original score. "N/A" is shown for the score.
5.) Albums with no current score display as "N/A" and average score is calculated without including nulls.
6.) Added 2025